### PR TITLE
Update my_supervisor.ex to not to restart Supervisor itself

### DIFF
--- a/10_process/16_my_supervisor/lib_sol/my_supervisor.ex
+++ b/10_process/16_my_supervisor/lib_sol/my_supervisor.ex
@@ -5,8 +5,6 @@ defmodule MySupervisor do
   end
 
   def supervise(children) do
-    Process.flag(:trap_exit, true)
-
     children
     |> Enum.map(&start/1)
     |> Enum.zip(children)
@@ -23,9 +21,6 @@ defmodule MySupervisor do
 
   def loop(children) do
     receive do
-      {:EXIT, _, _} ->
-        loop(children)
-
       {:DOWN, ref, :process, pid, _reason} ->
         down = {pid, ref}
         mod_args = children |> Map.get(down)


### PR DESCRIPTION
Supervisor does not restart itself.

https://github.com/elixir-lang/elixir/blob/v1.12.3/lib/elixir/lib/supervisor.ex

We can test the behaviour of MySupervisor(in lib_solution) and Elixir's canonical Supervisor with the test code below.


```elixir
    test "#{@sup_mod} for permanent restart" do
      Process.flag(:trap_exit, true)

      children = [
        # Terminate every 200ms
        {TimedBomb, 200}
      ]

      {:ok, sup} = @sup_mod.start_link(children, strategy: :one_for_one)

      Process.exit(sup, :normal)

      Process.sleep(300)

      refute Process.alive?(sup)
    end
```